### PR TITLE
JumpList icon fix

### DIFF
--- a/src/MarkPad/Shell/JumpListIntegration.cs
+++ b/src/MarkPad/Shell/JumpListIntegration.cs
@@ -102,7 +102,6 @@ namespace MarkPad.Shell
             return new JumpTask
                            {
                                Arguments = file,
-                               IconResourcePath = path,
                                ApplicationPath = path,
                                Title = new FileInfo(file).Name,
                                CustomCategory = "Recent Files"


### PR DESCRIPTION
DO NOT TEST IN DEBUGGER - YOU'LL SEE BLANK ICON AND ASSUME ITS BROKEN.

 http://stackoverflow.com/questions/5361096/wpf-jumptask-another-icon-than-the-default-one if you want to use  different icon to the exe's.
