### PR TITLE
Using TextOptions.TextFormattingMode="Display"

### DIFF
--- a/src/MarkPad/Document/DocumentView.xaml
+++ b/src/MarkPad/Document/DocumentView.xaml
@@ -516,6 +516,7 @@
             cal:Message.Attach="[Event TextChanged]=[Action Update]"
             Grid.Column="0"
             Margin="10,10,10,-5" 
+            TextOptions.TextFormattingMode="Display"
             VerticalAlignment="Stretch"
             HorizontalAlignment="Stretch" Padding="0,0,10,0">
             <avalonedit:TextEditor.Effect>


### PR DESCRIPTION
Using this setting on the Avalon text editor ensures that the fonts are clearer at 96DPI. 

A quick test is to type the letter L lowercase over and over - "llllllllllllllllllllllllllll". 

Without this change you'll see the L's blurring into each other. With the change, they will appear uniform. 
