### PR TITLE
Floating ToolBar

### DIFF
--- a/src/MarkPad/Document/DocumentView.xaml
+++ b/src/MarkPad/Document/DocumentView.xaml
@@ -6,10 +6,15 @@
     xmlns:System="clr-namespace:System;assembly=mscorlib"
     xmlns:shared="http://schemas.markpad.net/winfx/xaml/shared" xmlns:cal="http://www.caliburnproject.org"
     xmlns:awe="clr-namespace:Awesomium.Windows.Controls;assembly=Awesomium.Windows.Controls" xmlns:avalonedit="http://icsharpcode.net/sharpdevelop/avalonedit"
+    xmlns:Document="clr-namespace:MarkPad.Document" xmlns:Framework="clr-namespace:MarkPad.Framework"
     x:Class="MarkPad.Document.DocumentView"
     mc:Ignorable="d" 
     d:DesignHeight="300" d:DesignWidth="300"
 >
+    <UserControl.InputBindings>
+        <KeyBinding Command="Document:FormattingCommands.ToggleBold" Key="B" Modifiers="Control" />
+        <KeyBinding Command="Document:FormattingCommands.ToggleItalic" Key="I" Modifiers="Control" />
+    </UserControl.InputBindings>
     <UserControl.Resources>
         <ControlTemplate x:Key="HorizontalScrollBar"
                      TargetType="{x:Type ScrollBar}">
@@ -507,6 +512,17 @@
             <ColumnDefinition Width="*" />
             <ColumnDefinition Width="{Binding DistractionFree, Converter={shared:BoolToGridLengthConverter Invert=True}}" />
         </Grid.ColumnDefinitions>
+
+        <Framework:FloatingToolBar x:Name="floatingToolBar" PlacementTarget="{Binding ElementName=Editor}" CommandTarget="{Binding ElementName=root}" VerticalOffset="-60" HorizontalOffset="-30">
+            <Border Background="#f0f0f0" Padding="3,2,3,2" BorderThickness="1" CornerRadius="1" BorderBrush="#999999">
+                <StackPanel Orientation="Horizontal">
+                    <Button Width="22"  Command="Document:FormattingCommands.ToggleBold" ToolTip="Bold">B</Button>
+                    <Button Width="22" Command="Document:FormattingCommands.ToggleItalic" ToolTip="Italic">I</Button>
+                    <Button Width="44" Command="Document:FormattingCommands.ToggleCode" ToolTip="Code" Margin="5,0,0,0">Code</Button>
+                    <Button Width="78" Command="Document:FormattingCommands.ToggleCodeBlock" ToolTip="Code block">Code block</Button>
+                </StackPanel>
+            </Border>
+        </Framework:FloatingToolBar>
 
         <avalonedit:TextEditor
             x:Name="Editor"

--- a/src/MarkPad/Document/DocumentView.xaml.cs
+++ b/src/MarkPad/Document/DocumentView.xaml.cs
@@ -1,7 +1,9 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Reflection;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 using System.Windows.Media;
 using System.Xml;
 using Awesomium.Core;
@@ -19,6 +21,15 @@ namespace MarkPad.Document
             InitializeComponent();
             Loaded += DocumentViewLoaded;
             wb.Loaded += WbLoaded;
+
+            Editor.TextArea.SelectionChanged += SelectionChanged;
+
+            Editor.PreviewMouseLeftButtonUp += HandleMouseUp;
+
+            CommandBindings.Add(new CommandBinding(FormattingCommands.ToggleBold, (x, y) => ToggleBold(), CanEditDocument));
+            CommandBindings.Add(new CommandBinding(FormattingCommands.ToggleItalic, (x, y) => ToggleItalic(), CanEditDocument));
+            CommandBindings.Add(new CommandBinding(FormattingCommands.ToggleCode, (x, y) => ToggleCode(), CanEditDocument));
+            CommandBindings.Add(new CommandBinding(FormattingCommands.ToggleCodeBlock, (x, y) => ToggleCodeBlock(), CanEditDocument));
         }
 
         void WbLoaded(object sender, RoutedEventArgs e)
@@ -121,7 +132,33 @@ namespace MarkPad.Document
 
             Editor.SelectedText = Spaces + Editor.SelectedText.Replace(NewLine, NewLine + Spaces);
         }
+
+        private void SelectionChanged(object sender, EventArgs e)
+        {
+            if (Editor.TextArea.Selection.IsEmpty)
+            {
+                floatingToolBar.Hide();
+            }
+        }
+
+        private void HandleMouseUp(object sender, MouseButtonEventArgs e)
+        {
+            if (Editor.TextArea.Selection.IsEmpty)
+            {
+                floatingToolBar.Hide();
+            }
+            else
+            {
+                floatingToolBar.Show();
+            }
+        }
+
+        private void CanEditDocument(object sender, CanExecuteRoutedEventArgs e)
+        {
+            if (Editor != null && Editor.TextArea != null && Editor.TextArea.Selection != null)
+            {
+                e.CanExecute = !Editor.TextArea.Selection.IsEmpty;
+            }
+        }
     }
-
-
 }

--- a/src/MarkPad/Document/FormattingCommands.cs
+++ b/src/MarkPad/Document/FormattingCommands.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Windows.Input;
+
+namespace MarkPad.Document
+{
+    public class FormattingCommands
+    {
+        public static ICommand ToggleBold = new RoutedCommand();
+        public static ICommand ToggleItalic = new RoutedCommand();
+        public static ICommand ToggleCode = new RoutedCommand();
+        public static ICommand ToggleCodeBlock = new RoutedCommand();
+    }
+}

--- a/src/MarkPad/Framework/FloatingToolBar.cs
+++ b/src/MarkPad/Framework/FloatingToolBar.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Controls.Primitives;
+using System.Windows.Input;
+
+namespace MarkPad.Framework
+{
+    public class FloatingToolBar : Popup
+    {
+        public static readonly DependencyProperty CommandTargetProperty = DependencyProperty.Register("CommandTarget", typeof(ICommandSource), typeof(FloatingToolBar), new UIPropertyMetadata(null));
+        private Window window;
+
+        public FloatingToolBar()
+        {
+            AllowsTransparency = true;
+            Loaded += ControlLoaded;
+            Unloaded += ControlUnloaded;
+            StaysOpen = true;
+            FocusManager.SetIsFocusScope(this, true);
+        }
+
+        public ICommandSource CommandTarget
+        {
+            get { return (ICommandSource)GetValue(CommandTargetProperty); }
+            set { SetValue(CommandTargetProperty, value); }
+        }
+
+        public FrameworkElement Content
+        {
+            get
+            {
+                var content = Child as FrameworkElement;
+                if (content == null)
+                {
+                    throw new Exception("The FloatingToolBar requires a FrameworkElement to be its content");
+                }
+
+                return content;
+            }
+        }
+
+        private void ControlLoaded(object sender, RoutedEventArgs e)
+        {
+            window = Window.GetWindow(this);
+            Attach();
+        }
+
+        private void Attach()
+        {
+            if (PlacementTarget == null)
+                return;
+
+            PlacementTarget.LostFocus += Hide;
+
+            if (window != null)
+            {
+                window.LocationChanged += LocationChanged;
+                window.PreviewMouseMove += MouseMoved;
+                window.Deactivated += WindowDeactivated;
+            }
+        }
+
+        public void Hide()
+        {
+            Content.Opacity = 0;
+            IsOpen = false;
+        }
+
+        public void Show()
+        {
+            Hide();
+
+            Placement = PlacementMode.Mouse;
+
+            UpdateOpacity();
+            IsOpen = true;
+            UpdateOpacity();
+        }
+
+        private void MouseMoved(object sender, MouseEventArgs e)
+        {
+            UpdateOpacity();
+        }
+
+        private void UpdateOpacity()
+        {
+            if (Content.IsMouseDirectlyOver)
+            {
+                Opacity = 1;
+                return;
+            }
+
+            var position = Mouse.GetPosition(window);
+            var distance = Content.DistanceFromPoint(position, window);
+
+            if (distance < 2)
+            {
+                Content.Opacity = 1;
+            }
+            else if (distance > 30)
+            {
+                Content.Opacity = 0.2;
+            }
+            else
+            {
+                Content.Opacity = ((30 - distance) / 30.00) + 0.2;
+            }
+
+            if (Content.Opacity < 0.2)
+            {
+                Content.Opacity = 0.2;
+            }
+        }
+
+        private void WindowDeactivated(object sender, EventArgs e)
+        {
+            Hide();
+        }
+
+        private void LocationChanged(object sender, EventArgs e)
+        {
+            if (IsOpen)
+            {
+                Show();
+            }
+        }
+
+        private void ControlUnloaded(object sender, RoutedEventArgs e)
+        {
+            Detach();
+        }
+
+        private void Hide(object sender, RoutedEventArgs e)
+        {
+            IsOpen = false;
+        }
+
+        private void Detach()
+        {
+            if (PlacementTarget == null)
+                return;
+
+            PlacementTarget.LostFocus -= Hide;
+
+            if (window != null)
+            {
+                window.PreviewMouseMove -= MouseMoved;
+                window.LocationChanged -= LocationChanged;
+                window.Deactivated -= WindowDeactivated;
+            }
+        }
+    }
+}

--- a/src/MarkPad/Framework/VisualExtensions.cs
+++ b/src/MarkPad/Framework/VisualExtensions.cs
@@ -23,5 +23,82 @@ namespace MarkPad.Framework
             }
             return null;
         }
+
+        public static double DistanceFromPoint(this FrameworkElement visual, Point point, UIElement pointIsRelativeTo)
+        {
+            var relativeVisualPosition = visual.TranslatePoint(new Point(0, 0), pointIsRelativeTo);
+            var rectangle = new Rect(0, 0, visual.ActualWidth, visual.ActualHeight);
+            rectangle.Offset(relativeVisualPosition.X, relativeVisualPosition.Y);
+
+            if (rectangle.Contains(point))
+            {
+                return 0;
+            }
+
+            var distances = new[]
+            {
+                LineToPointDistance2D(rectangle.TopLeft, rectangle.TopRight, point, true),
+                LineToPointDistance2D(rectangle.TopRight, rectangle.BottomRight, point, true),
+                LineToPointDistance2D(rectangle.BottomRight, rectangle.BottomLeft, point, true),
+                LineToPointDistance2D(rectangle.BottomLeft, rectangle.TopLeft, point, true)
+            };
+
+            return distances.Min();
+        }
+
+        //Compute the dot product AB . AC
+        static double DotProduct(Point pointA, Point pointB, Point pointC)
+        {
+            double[] AB = new double[2];
+            double[] BC = new double[2];
+            AB[0] = pointB.X - pointA.X;
+            AB[1] = pointB.Y - pointA.Y;
+            BC[0] = pointC.X - pointB.X;
+            BC[1] = pointC.Y - pointB.Y;
+            double dot = AB[0] * BC[0] + AB[1] * BC[1];
+
+            return dot;
+        }
+
+        //Compute the cross product AB x AC
+        static double CrossProduct(Point pointA, Point pointB, Point pointC)
+        {
+            double[] AB = new double[2];
+            double[] AC = new double[2];
+            AB[0] = pointB.X - pointA.X;
+            AB[1] = pointB.Y - pointA.Y;
+            AC[0] = pointC.X - pointA.X;
+            AC[1] = pointC.Y - pointA.Y;
+            double cross = AB[0] * AC[1] - AB[1] * AC[0];
+
+            return cross;
+        }
+
+        //Compute the distance from A to B
+        static double Distance(Point pointA, Point pointB)
+        {
+            double d1 = pointA.X - pointB.X;
+            double d2 = pointA.Y - pointB.Y;
+
+            return Math.Sqrt(d1 * d1 + d2 * d2);
+        }
+
+        //Compute the distance from AB to C
+        //if isSegment is true, AB is a segment, not a line.
+        static double LineToPointDistance2D(Point pointA, Point pointB, Point pointC, bool isSegment)
+        {
+            double dist = CrossProduct(pointA, pointB, pointC) / Distance(pointA, pointB);
+            if (isSegment)
+            {
+                double dot1 = DotProduct(pointA, pointB, pointC);
+                if (dot1 > 0)
+                    return Distance(pointB, pointC);
+
+                double dot2 = DotProduct(pointB, pointA, pointC);
+                if (dot2 > 0)
+                    return Distance(pointA, pointC);
+            }
+            return Math.Abs(dist);
+        }
     }
 }

--- a/src/MarkPad/MarkPad.csproj
+++ b/src/MarkPad/MarkPad.csproj
@@ -104,13 +104,15 @@
     <Reference Include="PresentationFramework" />
   </ItemGroup>
   <ItemGroup>
-   <Compile Include="About\AboutView.xaml.cs">
+    <Compile Include="About\AboutView.xaml.cs">
       <DependentUpon>AboutView.xaml</DependentUpon>
     </Compile>
     <Compile Include="About\AboutViewModel.cs" />
+    <Compile Include="Document\FormattingCommands.cs" />
+    <Compile Include="Framework\FloatingToolBar.cs" />
     <Compile Include="Framework\ObjectExtensions.cs" />
     <Compile Include="Framework\InputBindingTrigger.cs" />
-<Compile Include="Settings\BlogSetting.cs" />
+    <Compile Include="Settings\BlogSetting.cs" />
     <Compile Include="Settings\BlogSettingsView.xaml.cs">
       <DependentUpon>BlogSettingsView.xaml</DependentUpon>
     </Compile>


### PR DESCRIPTION
This is a fix for this issue: 
https://github.com/Code52/DownmarkerWPF/issues/31

A Word-like floating ToolBar that appears when you use the mouse to select text, based on the Popup control. 

Also added keyboard bindings for Ctrl+B and Ctrl+I (bold/italic). 

![Example](http://www.paulstovell.com/get/temp/Bold.png)
