### PR TITLE
Small bug fix for FloatingToolBar

### DIFF
--- a/src/MarkPad/Framework/FloatingToolBar.cs
+++ b/src/MarkPad/Framework/FloatingToolBar.cs
@@ -121,7 +121,7 @@ namespace MarkPad.Framework
         {
             if (IsOpen)
             {
-                Show();
+                Hide();
             }
         }
 


### PR DESCRIPTION
If you move the window around while the toolbar is open, it will now close.
