### PR TITLE
Full support for MKD extension

### DIFF
--- a/src/MarkPad/Settings/SettingsView.xaml
+++ b/src/MarkPad/Settings/SettingsView.xaml
@@ -6,7 +6,7 @@
         MouseLeftButtonDown="DragMoveWindow" 
         ShowInTaskbar="False"
         SnapsToDevicePixels="True"
-        WindowStartupLocation="CenterOwner" Width="300" Height="320" ResizeMode="NoResize">
+        WindowStartupLocation="CenterOwner" Width="300" Height="365" ResizeMode="NoResize">
     <i:Interaction.Behaviors>
     <Behaviours:BorderlessWindowBehavior ResizeWithGrip="False" />
     </i:Interaction.Behaviors>
@@ -34,8 +34,8 @@
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
+            <RowDefinition Height="93" />
+            <RowDefinition Height="107*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <TextBlock TextWrapping="Wrap" VerticalAlignment="Top" FontFamily="Segoe UI" FontWeight="Light" FontSize="29.333" Text="settings" />
@@ -50,7 +50,8 @@
             <CheckBox x:Name="FileMDBinding" Content=".md" />
             <CheckBox x:Name="FileMDownBinding" Content=".mdown" />
             <CheckBox x:Name="FileMarkdownBinding" Content=".markdown" />
-        </StackPanel>
+			<CheckBox x:Name="FileMKDBinding" Content=".mkd"  />
+		</StackPanel>
         <StackPanel Grid.Row="2" Margin="0 10 0 0">
             <TextBlock Text="Blog Sites" />
             <StackPanel Orientation="Horizontal">

--- a/src/MarkPad/Settings/SettingsViewModel.cs
+++ b/src/MarkPad/Settings/SettingsViewModel.cs
@@ -35,6 +35,9 @@ namespace MarkPad.Settings
 
                 FileMDownBinding = key.GetSubKeyNames().Contains(Constants.DefaultExtensions[2]) &&
                     !string.IsNullOrEmpty(key.OpenSubKey(Constants.DefaultExtensions[2]).GetValue("").ToString());
+
+                FileMKDBinding = key.GetSubKeyNames().Contains(Constants.DefaultExtensions[3]) &&
+                    !string.IsNullOrEmpty(key.OpenSubKey(Constants.DefaultExtensions[3]).GetValue("").ToString());
             }
 
             var blogs = settingsService.Get<List<BlogSetting>>("Blogs") ?? new List<BlogSetting>();
@@ -45,6 +48,7 @@ namespace MarkPad.Settings
         public bool FileMDBinding { get; set; }
         public bool FileMarkdownBinding { get; set; }
         public bool FileMDownBinding { get; set; }
+        public bool FileMKDBinding { get;	set; }
 
         public BlogSetting CurrentBlog { get; set; }
         public ObservableCollection<BlogSetting> Blogs { get; set; }
@@ -129,7 +133,8 @@ namespace MarkPad.Settings
                     {
                         if ((i == 0 && FileMDBinding) ||
                             (i == 1 && FileMarkdownBinding) ||
-                            (i == 2 && FileMDownBinding))
+                            (i == 2 && FileMDownBinding) ||
+                            (i == 3 && FileMKDBinding))
                             extensionKey.SetValue("", markpadKeyName);
                         else
                             extensionKey.SetValue("", "");


### PR DESCRIPTION
This is a follow up with full support for the MKD extension that @shanselman started in pull request 17c5704543.
- added checkbox UI element for extension to settings dialog
- added binding property to the model for the MKD extension
- added support for loading/saving whether the setting is associated in the registry
