### PR TITLE
Bring the Chocolatey package into the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ Packages
 *.suo
 *.user
 *.dat
+*.nupkg
 
 _Resharper*

--- a/chocolateyInstall.ps1
+++ b/chocolateyInstall.ps1
@@ -1,0 +1,18 @@
+try 
+{ 
+  $name    = 'markpad'
+  $url     = 'https://github.com/downloads/Code52/DownmarkerWPF/Markpad.1.0.1.zip'
+  $tools   = Split-Path $MyInvocation.MyCommand.Definition
+  $content = Join-Path (Split-Path $tools) 'content'
+  $target  = Join-Path $content 'MarkPad.exe'
+  
+  Install-ChocolateyZipPackage $name $url $content
+  Install-ChocolateyDesktopLink $target
+  
+  Write-ChocolateySuccess $name
+} 
+catch 
+{
+  Write-ChocolateyFailure $name "$($_.Exception.Message)"
+  throw 
+}

--- a/markpad.nuspec
+++ b/markpad.nuspec
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>markpad</id>
+    <title>Markpad</title>
+    <version>1.0.1</version>
+    <authors>Code52</authors>
+    <owners>Code52</owners>
+    <projectUrl>http://code52.org/DownmarkerWPF/</projectUrl>
+    <iconUrl>http://code52.org/DownmarkerWPF/icon.png</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>A WPF Markdown editor inspired by Downmarker.</description>
+    <summary>A WPF Markdown editor inspired by Downmarker.</summary>
+    <tags>markdown downmarker wpf markpad chocolatey</tags>
+  </metadata>
+  <files>
+    <file src="chocolateyInstall.ps1" target="tools\chocolateyInstall.ps1" />
+  </files>
+</package>


### PR DESCRIPTION
Starts to fix #107. Right now it's just the nuspec and install script. I have updated the owner to be 'Code52'. And I tweaked the install to create a desktop shortcut (the only supported shortcut for GUI apps right now).

If the WiX installer takes off, maybe we ref that instead of the zip download here.
