### PR TITLE
small tweaks to the build.bat

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,13 +1,12 @@
 @ECHO OFF
 
 SET msbuild="%windir%\Microsoft.NET\Framework\v4.0.30319\msbuild.exe"
-SET nuget=%~dp0\.nuget\nuget.exe
 
 IF '%1'=='' (SET configuration=Debug) ELSE (SET configuration=%1)
 
 :: Build the solution. Override the platform to account for running
 :: from Visual Studio Tools command prompt (x64). Log quietly to the 
 :: console and verbosely to a file.
-%msbuild% MarkPad.sln /nologo /property:Configuration=%configuration% /verbosity:minimal /flp:verbosity=diagnostic
+%msbuild% MarkPad.sln /nologo /property:Platform=x86 /property:Configuration=%configuration% /verbosity:minimal /flp:verbosity=diagnostic
 
 IF NOT ERRORLEVEL 0 EXIT /B %ERRORLEVEL%


### PR DESCRIPTION
- Removed a leftover experimental %nuget% variable.
- Added the `/p:Platform=x86` back in, because, if you're working in a x64 Visual Studio tools prompt (likely on x64 systems), your platform is set to x64 and this batch file would fail mysteriously.
