### PR TITLE
Removing the "all arguments" argument

### DIFF
--- a/build-Release.bat
+++ b/build-Release.bat
@@ -3,6 +3,6 @@
 SET build=%~dp0\build.bat
 
 :: Pass the configuration parameter and all other parameters
-CALL %build% Release %*
+CALL %build% Release
 
 IF NOT ERRORLEVEL 0 EXIT /B %ERRORLEVEL%


### PR DESCRIPTION
I didn't realize the implications of passing "all args" into the next batch file. I thought you could use it from the command line like

```
cmd> build-Release.bat /p:CustomParam=Whatever
```

However, in the next batch file, you'd have to do some [crazy batch for looping](http://stackoverflow.com/a/761658/3619) to get the "remaining" arguments. Since, in that batch file, `%*` would have the `%configuration%` and everything else in it. Capische?
