### PR TITLE
Allow for spaces in the build path in build-Release.bat

### DIFF
--- a/build-Release.bat
+++ b/build-Release.bat
@@ -1,6 +1,6 @@
 @ECHO OFF
 
-SET build=%~dp0\build.bat
+SET build="%~dp0\build.bat"
 
 :: Pass the configuration parameter and all other parameters
 CALL %build% Release


### PR DESCRIPTION
When i tried running build-Release.bat, it failed because my project was a child of the "Visual Studio 2010" directory.

i'm not sure if this will work universally, but it allowed me to build the Release version correctly.
