### PR TITLE
Single tab per filename

### DIFF
--- a/src/MarkPad/Document/DocumentViewModel.cs
+++ b/src/MarkPad/Document/DocumentViewModel.cs
@@ -162,6 +162,11 @@ namespace MarkPad.Document
             get { return title; }
         }
 
+        public string FileName
+        {
+            get { return filename; } 
+        }
+
         public override void CanClose(Action<bool> callback)
         {
             DocumentView view = (DocumentView)this.GetView();


### PR DESCRIPTION
Opening given filename multiple times will result in one tab. Opening files will same name but different paths is possible so it would be nice to add some indication about active tab path.
