### PR TITLE
#141 fixes open from web experience when there is no blog

### DIFF
--- a/src/MarkPad/Settings/SettingsViewModel.cs
+++ b/src/MarkPad/Settings/SettingsViewModel.cs
@@ -74,7 +74,7 @@ namespace MarkPad.Settings
             set { }
         }
 
-        public void AddBlog()
+        public bool AddBlog()
         {
             var blog = new BlogSetting { BlogName = "New", Language = "HTML" };
 
@@ -87,12 +87,14 @@ namespace MarkPad.Settings
             if (result != true)
             {
                 blog.CancelEdit();
-                return;
+                return false;
             }
 
             blog.EndEdit();
 
             Blogs.Add(blog);
+
+			return true;
         }
 
         public void EditBlog()

--- a/src/MarkPad/Shell/ShellViewModel.cs
+++ b/src/MarkPad/Shell/ShellViewModel.cs
@@ -240,13 +240,17 @@ namespace MarkPad.Shell
             var blogs = settingsService.Get<List<BlogSetting>>("Blogs");
             if (blogs == null || blogs.Count == 0)
             {
-                var setupBlog = dialogService.ShowConfirmation("No blogs setup", "Do you want to setup a blog?", "", 
-                    new ButtonExtras(ButtonType.Yes, "Yes", "Setup a blog"),
-                    new ButtonExtras(ButtonType.No, "No", "Don't setup a blog now"));
+                var setupBlog = dialogService.ShowConfirmation(
+					"Open from web",
+					"Do you want to configure a blog site?",
+					"No blog sites have been configured. To open a document from the web, MarkPad first needs to be integrated with a blog site.");
 
-                if (setupBlog)
-                    ShowSettings();
-                return;
+				if (!setupBlog)
+					return;
+
+				var settings = settingsCreator();
+				if (!settings.AddBlog())
+					return;                    
             }
 
             var openFromWeb = openFromWebCreator();


### PR DESCRIPTION
When opening from web with no blog sites configured, the prompt reads a bit nicer IMO and it opens the new blog settings directly rather than just opening the settings page.
