### PR TITLE
Issue 118 - added a help command

### DIFF
--- a/src/MarkPad/Help.md
+++ b/src/MarkPad/Help.md
@@ -1,0 +1,49 @@
+﻿# Markdown cheat sheet
+
+## Text Formatting
+
+This is how to do **bold** text.
+This is how to do *italic* text.
+You can also do __bold__ like this.
+You can also do _italic_ like this.
+
+> This is how to make a blockquote
+
+## Links
+
+For a full description of the markdown syntax, visit [this page](http://daringfireball.net/projects/markdown/syntax)
+
+## Lists
+
+Unordered lists:
+
+* item 1
++ item 2
+- item 3
+
+Ordered lists:
+
+1. hello
+2. world
+
+Nested lists
+
+* a
+    * b
+    * c
+* d
+
+## Code
+
+    var x = new Foo();
+    x.Bar();
+
+# This is an H1
+
+## This is an H2
+
+This is also an H1
+===========
+
+This is also an H2
+------------------

--- a/src/MarkPad/MarkPad.csproj
+++ b/src/MarkPad/MarkPad.csproj
@@ -265,6 +265,7 @@
     <None Include="app.config">
       <SubType>Designer</SubType>
     </None>
+    <EmbeddedResource Include="Help.md" />
     <None Include="Metaweblog\Generated\BloggerAPI.json" />
     <None Include="Metaweblog\Generated\MetaWeblog.tt">
       <Generator>TextTemplatingFileGenerator</Generator>

--- a/src/MarkPad/Shell/ShellView.xaml
+++ b/src/MarkPad/Shell/ShellView.xaml
@@ -201,6 +201,7 @@
                 <Button x:Name="SaveAllDocuments" Content="SAVE ALL" />
                 <Button x:Name="PrintDocument" Content="PRINT" />
                 <Button x:Name="PublishDocument" Content="PUBLISH" />
+                <Button x:Name="ShowHelp" Content="HELP" />
             </WrapPanel>
             <StackPanel HorizontalAlignment="Right" VerticalAlignment="Top" Margin="10" Orientation="Horizontal">
                 <Button x:Name="ShowSettings" Content="SETTINGS" Style="{DynamicResource ChromelessButtonStyle}" FontSize="10.667" Margin="0,0,0,0" FontWeight="Bold" />

--- a/src/MarkPad/Shell/ShellViewModel.cs
+++ b/src/MarkPad/Shell/ShellViewModel.cs
@@ -13,6 +13,7 @@ using MarkPad.Services.Interfaces;
 using MarkPad.Settings;
 using Ookii.Dialogs.Wpf;
 using System.Linq;
+using System.Reflection;
 
 namespace MarkPad.Shell
 {
@@ -218,7 +219,24 @@ namespace MarkPad.Shell
                 .ExecuteSafely(v => v.SetHyperlink());
         }
 
+        public void ShowHelp()
+        {
+            var creator = documentCreator();
+            creator.Original = GetHelpText(); // set the Original so it isn't marked as requiring a save unless we change it
+            creator.Document.Text = creator.Original;
+            MDI.Open(creator);
+            creator.Update(); // ensure that the markdown is rendered
+        }
 
+        private string GetHelpText()
+        {
+            var resourcePath = "MarkPad.Help.md";
+            using (var resourceStream = Assembly.GetExecutingAssembly().GetManifestResourceStream(resourcePath))
+            using (var streamReader = new System.IO.StreamReader(resourceStream))
+            {
+                return streamReader.ReadToEnd();
+            }
+        }
 
         public void PublishDocument()
         {


### PR DESCRIPTION
Just a very simple implementation:
- added a "help" option in the shell view
- added a help.md file as an embedded resource with some basic markdown help
- when you click help, a new document is created containing the markdown help

I've made it so the document is not initially marked as dirty, so no prompt to save if you just look and then close, but if you edit it, you will be prompted to save your changes (obviously the embedded file would not change).

There are lots of improvements that could be made to how this works, but I think this is a resonable start, and didn't want to do any major refactoring.
