### PR TITLE
#159 handles invalid cast exception when getting settings

### DIFF
--- a/src/MarkPad.Services/Implementation/SettingsService.cs
+++ b/src/MarkPad.Services/Implementation/SettingsService.cs
@@ -32,8 +32,15 @@ namespace MarkPad.Services.Implementation
 
         public T Get<T>(string key)
         {
-            if (storage.ContainsKey(key))
-                return (T)storage[key];
+			try
+			{
+				if (storage.ContainsKey(key))
+					return (T)storage[key];
+			}
+			catch (InvalidCastException e)
+			{
+				Trace.Write(e, "WARN");
+			}
             return default(T);
         }
 


### PR DESCRIPTION
Catches, logs, returns null. This could cause issues by hiding the exception when developing, but reduces the chance of an end user ending up with an unusable installation.
