### PR TITLE
Added in document closing with Ctrl+W hotkey

### DIFF
--- a/src/MarkPad/Shell/ShellView.xaml
+++ b/src/MarkPad/Shell/ShellView.xaml
@@ -105,6 +105,12 @@
             </s:InputBindingTrigger.InputBinding>
             <cm:ActionMessage MethodName="OpenDocument" />
         </s:InputBindingTrigger>
+        <s:InputBindingTrigger>
+            <s:InputBindingTrigger.InputBinding>
+                <KeyBinding Modifiers="Ctrl" Key="W" />
+            </s:InputBindingTrigger.InputBinding>
+            <cm:ActionMessage MethodName="CloseDocument" />
+        </s:InputBindingTrigger>
     </i:Interaction.Triggers>
 
     <Window.Background>

--- a/src/MarkPad/Shell/ShellViewModel.cs
+++ b/src/MarkPad/Shell/ShellViewModel.cs
@@ -147,6 +147,15 @@ namespace MarkPad.Shell
             }
         }
 
+        public void CloseDocument()
+        {
+            var doc = MDI.ActiveItem as DocumentViewModel;
+            if (doc != null)
+            {
+                MDI.CloseItem(doc);
+            }
+        }
+
         public void Handle(FileOpenEvent message)
         {
             var doc = documentCreator();


### PR DESCRIPTION
Requested hotkey from issue #175. Only includes the Ctrl+W shortcut. No work toward dynamically mapping hotkeys
