### PR TITLE
Bugfix for script

### DIFF
--- a/Normalize-crlf.ps1
+++ b/Normalize-crlf.ps1
@@ -1,5 +1,5 @@
 foreach ($ext in @("*.cs", "*.md", "*.csproject", "*.sln", "*.xaml", "*.targets"))  {
-	(dir -Recurse -Filter $ext) | foreach { 
+	(dir -Recurse -Filter $ext) | where{!$_.PsIsContainer} | foreach { 
 		$file = gc $_.FullName
 		$file | sc $_.FullName
 		}


### PR DESCRIPTION
Repro: 
- open powershell console and run script
- script detects MarkPad.XAML (folder) as valid XAML file and attempts to open folder like a file
- boom

Fix:
- Using a filter like [this](http://www.powershellcommunity.org/Forums/tabid/54/aft/4747/Default.aspx) - there may be a more trendy Powershell way to implement this.
