### PR TITLE
Handle bad urls and browser refresh

### DIFF
--- a/src/MarkPad.Services/MarkPad.Services.csproj
+++ b/src/MarkPad.Services/MarkPad.Services.csproj
@@ -106,8 +106,8 @@
     <Compile Include="Metaweblog\Generated\MetaWeblog.generated.cs">
       <DependentUpon>MetaWeblog.tt</DependentUpon>
       <AutoGen>True</AutoGen>
-      <SubType>Component</SubType>
       <DesignTime>True</DesignTime>
+      <SubType>Component</SubType>
     </Compile>
     <Compile Include="Metaweblog\MediaObject.cs" />
     <Compile Include="Metaweblog\MediaObjectInfo.cs" />

--- a/src/MarkPad/Document/DocumentView.xaml.cs
+++ b/src/MarkPad/Document/DocumentView.xaml.cs
@@ -59,6 +59,8 @@ namespace MarkPad.Document
 			// doesn't allow disabling or hijacking refresh.
 			wb.ResourceRequest += new ResourceRequestEventHandler((o, e) =>
 			{
+				if (e.Request.Url != "local://base_request.html/") return null;
+
 				Task.Factory
 					.StartNew(() => System.Threading.Thread.Sleep(100))
 					.ContinueWith(t => this.Dispatcher.Invoke(new System.Action(() =>


### PR DESCRIPTION
Steps to reproduce:

1) User writes some markup which has an invalid resource (e.g. image)
2) User right-clicks in preview pane and selects Refresh
3) Preview pane displays: "Error: Generic Failure Occurred" message

App should be more robust and handle these issues using hooks from Awesomium.
