### PR TITLE
Fixing issues in image pasting

### DIFF
--- a/src/MarkPad.Services/Implementation/JekyllSiteContext.cs
+++ b/src/MarkPad.Services/Implementation/JekyllSiteContext.cs
@@ -26,7 +26,13 @@ namespace MarkPad.Services.Implementation
             if (!Directory.Exists(absoluteImagePath))
                 Directory.CreateDirectory(absoluteImagePath);
 
-            var filename = Path.GetFileNameWithoutExtension(filenameWithPath);
+            var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(filenameWithPath);
+            if (fileNameWithoutExtension == null)
+                return null;
+
+            var filename = fileNameWithoutExtension
+                .Replace(" ", string.Empty)
+                .Replace(".", string.Empty);
             var count = 1;
             var imageFilename = filename + ".png";
 

--- a/src/MarkPad.Services/Implementation/SiteContextGenerator.cs
+++ b/src/MarkPad.Services/Implementation/SiteContextGenerator.cs
@@ -13,21 +13,23 @@ namespace MarkPad.Services.Implementation
             if (directoryName == null) return null;
 
             var directory = new DirectoryInfo(directoryName);
-            if (IsJekyllSite(filename, directory))
+            var jekyllSiteBaseDirectory = GetJekyllSiteBaseDirectory(directory);
+            if (jekyllSiteBaseDirectory != null)
             {
-                var baseDirectory = GetBaseDirectory(directory);
-                return new JekyllSiteContext(baseDirectory, filename);
+                return new JekyllSiteContext(jekyllSiteBaseDirectory, filename);
             }
 
             return null;
         }
 
-        private string GetBaseDirectory(DirectoryInfo startDirectory)
+        private string GetJekyllSiteBaseDirectory(DirectoryInfo startDirectory)
         {
+            if (startDirectory == null)
+                return null;
             if (ContainsJekyllConfigFile(startDirectory))
                 return startDirectory.FullName;
 
-            return GetBaseDirectory(startDirectory.Parent);
+            return GetJekyllSiteBaseDirectory(startDirectory.Parent);
         }
 
         private static bool IsJekyllSite(string filename, DirectoryInfo directory)

--- a/src/MarkPad/Document/DocumentView.xaml.cs
+++ b/src/MarkPad/Document/DocumentView.xaml.cs
@@ -479,7 +479,9 @@ namespace MarkPad.Document
                         {
                             var relativePath = siteContext.SaveImage(dataImage.Bitmap);
 
-                            sb.AppendLine(string.Format("![{0}]({1})", Path.GetFileNameWithoutExtension(relativePath), relativePath));
+                            sb.AppendLine(string.Format("![{0}](/{1})",
+                                Path.GetFileNameWithoutExtension(relativePath), 
+                                relativePath.TrimStart('/').Replace('\\', '/')));
                         }
 
                         textArea.Selection.ReplaceSelectionWithText(textArea, sb.ToString().Trim());


### PR DESCRIPTION
Possible to generate image names which are not parsed by markdown, and also page context was not picked up if the page is in a folder of the site (which is perfectly valid for Jekyll pages)
