### PR TITLE
Moved wordcount into viewmodel, and updates with render refresh. Also ma...

### DIFF
--- a/src/MarkPad/Document/DocumentView.xaml
+++ b/src/MarkPad/Document/DocumentView.xaml
@@ -59,7 +59,8 @@
         </TreeView>
         
         <Document:MarkdownEditor x:Name="markdownEditor"
-                                 Grid.Column="1" />
+                                 Grid.Column="1"
+                                 Document="{Binding Document}"/>
 
         <Slider x:Name="ZoomSlider"
                 Maximum="2"
@@ -71,11 +72,15 @@
                 Margin="0,0,40,20"
                 Grid.Column="1" />
 
-        <Label Name="WordCount"
-               VerticalAlignment="Bottom"
+        <Label VerticalAlignment="Bottom"
                Margin="40,40,10,15"
                Grid.Column="1"
-               HorizontalAlignment="Left">          
+               HorizontalAlignment="Left"
+               IsHitTestVisible="False">
+            <TextBlock>
+                <TextBlock Text="wordcount: " />
+                <TextBlock Text="{Binding WordCount}"/>
+            </TextBlock>
         </Label>
 
        <awe:WebControl x:Name="wb" UseLayoutRounding="True" Margin="10,0,10,10" Grid.Column="2" HorizontalAlignment="Stretch" 

--- a/src/MarkPad/Document/DocumentView.xaml.cs
+++ b/src/MarkPad/Document/DocumentView.xaml.cs
@@ -46,7 +46,6 @@ namespace MarkPad.Document
             SizeChanged += DocumentViewSizeChanged;
             ZoomSlider.ValueChanged += (sender, e) => ApplyZoom();
             markdownEditor.Editor.MouseWheel += HandleEditorMouseWheel;
-            markdownEditor.Editor.KeyDown += WordCount_KeyDown;
 
             Handle(new SettingsChangedEvent());
 
@@ -64,28 +63,6 @@ namespace MarkPad.Document
         {
             if (!Keyboard.IsKeyDown(Key.LeftCtrl) && !Keyboard.IsKeyDown(Key.RightCtrl)) return;
             ZoomSlider.Value += e.Delta * 0.1;
-        }
-
-        void WordCount_KeyDown(object sender, KeyEventArgs e)
-        {
-            var vm = DataContext as DocumentViewModel;
-
-            var count = 0;
-
-            if (!string.IsNullOrEmpty(vm.Render))
-            {
-                count = GetWordCount(vm.Render);
-            }
-
-            WordCount.Content = "words: " + count;
-        }
-
-        private static int GetWordCount(string text)
-        {
-            var input = text;
-            input = Regex.Replace(input, @"(?s)<script.*?(/>|</script>)", string.Empty);
-            input = Regex.Replace(input, @"</?\w+((\s+\w+(\s*=\s*(?:"".*?""|'.*?'|[^'"">\s]+))?)+\s*|\s*)/?>", string.Empty);
-            return Regex.Matches(input, @"[\S]+").Count;
         }
 
         private void ApplyZoom()

--- a/src/MarkPad/Document/DocumentViewModel.cs
+++ b/src/MarkPad/Document/DocumentViewModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Net;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows.Threading;
 using Caliburn.Micro;
@@ -31,6 +32,8 @@ namespace MarkPad.Document
         private string title;
         private string filename;
 
+        readonly Regex wordCountRegex = new Regex(@"[\S]+", RegexOptions.Compiled);
+
         public DocumentViewModel(IDialogService dialogService, IWindowManager windowManager, ISiteContextGenerator siteContextGenerator, Func<string, IMetaWeblogService> getMetaWeblog)
         {
             this.dialogService = dialogService;
@@ -45,6 +48,11 @@ namespace MarkPad.Document
             timer = new DispatcherTimer();
             timer.Tick += TimerTick;
             timer.Interval = delay;
+        }
+
+        private void UpdateWordCount()
+        {
+            WordCount = wordCountRegex.Matches(Document.Text).Count;
         }
 
         private void TimerTick(object sender, EventArgs e)
@@ -67,6 +75,7 @@ namespace MarkPad.Document
                 }
 
                 Render = result;
+                UpdateWordCount();
             }, TaskScheduler.FromCurrentSynchronizationContext());
         }
 
@@ -264,6 +273,8 @@ namespace MarkPad.Document
         public bool DistractionFree { get; set; }
 
         public ISiteContext SiteContext { get; private set; }
+
+        public int WordCount { get; private set; }
 
         public void Publish(string postid, string postTitle, string[] categories, BlogSetting blog)
         {

--- a/src/MarkPad/Document/MarkdownEditor.xaml
+++ b/src/MarkPad/Document/MarkdownEditor.xaml
@@ -8,7 +8,8 @@
              xmlns:controls="clr-namespace:MarkPad.XAML.Controls;assembly=MarkPad.XAML"
              xmlns:Document="clr-namespace:MarkPad.Document" mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300"
-             Loaded="EditorLoaded">
+             Loaded="EditorLoaded"
+             x:Name="editor">
     <UserControl.Resources>
         <Style TargetType="{x:Type avalonedit:TextArea}">
             <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
@@ -74,7 +75,7 @@
             x:Name="Editor"
             WordWrap="True"
             ShowLineNumbers="True"
-            Document="{Binding Document}"
+            Document="{Binding Document, ElementName=editor}"
             cal:Message.Attach="[Event TextChanged]=[Action Update]"
             Grid.Column="0"
             Margin="10,0,10,10" 

--- a/src/MarkPad/Document/MarkdownEditor.xaml.cs
+++ b/src/MarkPad/Document/MarkdownEditor.xaml.cs
@@ -8,6 +8,7 @@ using System.Windows;
 using System.Windows.Input;
 using System.Xml;
 using ICSharpCode.AvalonEdit;
+using ICSharpCode.AvalonEdit.Document;
 using ICSharpCode.AvalonEdit.Highlighting;
 using ICSharpCode.AvalonEdit.Highlighting.Xshd;
 using ICSharpCode.AvalonEdit.Rendering;
@@ -38,6 +39,15 @@ namespace MarkPad.Document
             CommandBindings.Add(new CommandBinding(FormattingCommands.ToggleCodeBlock, (x, y) => ToggleCodeBlock(), CanEditDocument));
             CommandBindings.Add(new CommandBinding(FormattingCommands.SetHyperlink, (x, y) => SetHyperlink(),
                                                    CanEditDocument));
+        }
+
+        public static readonly DependencyProperty DocumentProperty =
+            DependencyProperty.Register("Document", typeof(TextDocument), typeof(MarkdownEditor), new PropertyMetadata(default(TextDocument)));
+
+        public TextDocument Document
+        {
+            get { return (TextDocument)GetValue(DocumentProperty); }
+            set { SetValue(DocumentProperty, value); }
         }
 
         public static readonly DependencyProperty FloatingToolbarEnabledProperty =


### PR DESCRIPTION
...de not hittest visible

Also made document a dependency property, so the MarkdownEditor.xaml doesnt care what the viewmodel is.
