### PR TITLE
Save/print/publish should be disabled when no files are open

### DIFF
--- a/src/MarkPad/MDI/MDIViewModel.cs
+++ b/src/MarkPad/MDI/MDIViewModel.cs
@@ -8,5 +8,26 @@ namespace MarkPad.MDI
         {
             this.ActivateItem(screen);
         }
+
+        /// <summary>
+        /// Gets value indicating whether any document is opened thus active.
+        /// </summary>
+        public bool IsDocumentActive
+        {
+            get { return ActiveItem != null; }
+        }
+
+        public override void ActivateItem(IScreen item)
+        {
+            base.ActivateItem(item);
+            NotifyOfPropertyChange("IsDocumentActive");
+        }
+
+        public override void DeactivateItem(IScreen item, bool close)
+        {
+            base.DeactivateItem(item, close);
+            NotifyOfPropertyChange("IsDocumentActive");
+        }
+
     }
 }

--- a/src/MarkPad/Shell/ShellView.xaml
+++ b/src/MarkPad/Shell/ShellView.xaml
@@ -317,15 +317,15 @@
     					</i:EventTrigger>
     				</i:Interaction.Triggers>
     			</Button>
-				<Button x:Name="ShowSave" Content="save" >
+                <Button x:Name="ShowSave" Content="save" IsEnabled="{Binding Mode=OneWay, Path=MDI.IsDocumentActive}">
     				<i:Interaction.Triggers>
     					<i:EventTrigger EventName="Click">
     						<ei:GoToStateAction StateName="SaveState"/>
     					</i:EventTrigger>
     				</i:Interaction.Triggers>
     			</Button>
-    			<Button x:Name="PrintDocument" Content="print" />
-    			<Button x:Name="PublishDocument" Content="publish" />
+                <Button x:Name="PrintDocument" Content="print" IsEnabled="{Binding Mode=OneWay, Path=MDI.IsDocumentActive}" />
+                <Button x:Name="PublishDocument" Content="publish" IsEnabled="{Binding Mode=OneWay, Path=MDI.IsDocumentActive}" />
     		</WrapPanel>
     		<WrapPanel x:Name="newItems" Margin="30,0,0,0" Opacity="0.995" VerticalAlignment="Bottom" Height="20" RenderTransformOrigin="0.5,0.5" d:LayoutOverrides="VerticalAlignment, GridBox">
     			<WrapPanel.Resources>


### PR DESCRIPTION
Save/print/publish are enabled only when there is an active document.
