### PR TITLE
expose toolbar enabled property to markdown editor (#233)

### DIFF
--- a/src/MarkPad/Document/DocumentViewModel.cs
+++ b/src/MarkPad/Document/DocumentViewModel.cs
@@ -220,6 +220,15 @@ namespace MarkPad.Document
             set { title = value; }
         }
 
+        public bool FloatingToolbarEnabled
+        {
+            get
+            {
+                var settings = settingsProvider.GetSettings<MarkPadSettings>();
+                return settings.FloatingToolBarEnabled;
+            }
+        }
+
         public override void CanClose(Action<bool> callback)
         {
             var view = GetView() as DocumentView;

--- a/src/MarkPad/Document/MarkdownEditor.xaml.cs
+++ b/src/MarkPad/Document/MarkdownEditor.xaml.cs
@@ -37,8 +37,7 @@ namespace MarkPad.Document
             CommandBindings.Add(new CommandBinding(FormattingCommands.ToggleItalic, (x, y) => ToggleItalic(), CanEditDocument));
             CommandBindings.Add(new CommandBinding(FormattingCommands.ToggleCode, (x, y) => ToggleCode(), CanEditDocument));
             CommandBindings.Add(new CommandBinding(FormattingCommands.ToggleCodeBlock, (x, y) => ToggleCodeBlock(), CanEditDocument));
-            CommandBindings.Add(new CommandBinding(FormattingCommands.SetHyperlink, (x, y) => SetHyperlink(),
-                                                   CanEditDocument));
+            CommandBindings.Add(new CommandBinding(FormattingCommands.SetHyperlink, (x, y) => SetHyperlink(), CanEditDocument));
         }
 
         public static readonly DependencyProperty DocumentProperty =
@@ -97,6 +96,8 @@ namespace MarkPad.Document
 
         private void SelectionChanged(object sender, EventArgs e)
         {
+            if (!FloatingToolbarEnabled) return;
+
             if (Editor.TextArea.Selection.IsEmpty)
                 floatingToolBar.Hide();
             else


### PR DESCRIPTION
Fixes the option to not show the floating toolbar
