### PR TITLE
Fix Open From Web

### DIFF
--- a/src/MarkPad/Document/DocumentViewModel.cs
+++ b/src/MarkPad/Document/DocumentViewModel.cs
@@ -106,7 +106,7 @@ namespace MarkPad.Document
         {
             Post = post;
 
-            title = post.permalink ?? string.Empty; // TODO: no title is displayed now
+            title = post.title ?? string.Empty;
             Document.Text = post.description ?? string.Empty;
             Original = post.description ?? string.Empty;
 

--- a/src/MarkPad/OpenFromWeb/OpenFromWebView.xaml
+++ b/src/MarkPad/OpenFromWeb/OpenFromWebView.xaml
@@ -50,7 +50,7 @@
                 <Button x:Name="Fetch" Content="Fetch" Margin="5 0 0 0" Width="50" />
             </StackPanel>
         </StackPanel>
-        <ListBox Grid.Row="1" Background="Transparent" x:Name="Posts" SelectedItem="CurrentPost">
+        <ListBox Grid.Row="1" Background="Transparent" x:Name="Posts" SelectedItem="{Binding CurrentPost}">
             <ListBox.ItemTemplate>
                 <DataTemplate>
                     <TextBlock Text="{Binding Key}" HorizontalAlignment="Stretch"/>


### PR DESCRIPTION
This fixes a bug in open from web where after you have already opened a document from the web, you cannot open a different document from the web until you restart the app. No matter which post you choose to open the second time it will just keep opening the first post you had opened.

The problem has to do with the binding off the list box and the selected post.

I Also added titles to posts opened from the web. Previously they were always blank.
