### PR TITLE
Null ref when closing app

### DIFF
--- a/src/MarkPad.PreviewControl/AwesomiumHost.cs
+++ b/src/MarkPad.PreviewControl/AwesomiumHost.cs
@@ -167,7 +167,10 @@ namespace MarkPad.PreviewControl
             app.Dispatcher.Invoke(new Action(() =>
             {
                 app.Shutdown();
-                wb.Close();
+                if (wb != null)
+                {
+                    wb.Close();
+                }
             }));
         }
 


### PR DESCRIPTION
If you close app before the html preview has initialized u will get a
null reference exception
