### PR TITLE
Fix startup crash issue with a NullReference exception

### DIFF
--- a/src/MarkPad/Settings/UI/SettingsViewModel.cs
+++ b/src/MarkPad/Settings/UI/SettingsViewModel.cs
@@ -116,7 +116,7 @@ namespace MarkPad.Settings.UI
 
         private static bool Enabled(string s, RegistryKey key, RegistryKey openSubKey)
         {
-            object defaultNameValue = openSubKey.GetValue(null);
+            object defaultNameValue = openSubKey == null? null : openSubKey.GetValue(null);
             string defaultNameValueAsString = defaultNameValue == null ? null : defaultNameValue.ToString();
             return openSubKey != null &&
                    (key.GetSubKeyNames().Contains(s) &&


### PR DESCRIPTION
The code
    private static bool Enabled(string s, RegistryKey key, RegistryKey openSubKey)
    {
         return openSubKey != null &&
            (key.GetSubKeyNames().Contains(s) &&
            !string.IsNullOrEmpty(openSubKey.GetValue("").ToString()));
    }
is causing startup crash with a NullReference excpetion if openSubKey.GetValue("") returns null. So the correct code should be
    private static bool Enabled(string s, RegistryKey key, RegistryKey openSubKey)
    {
        object defaultNameValue = openSubKey.GetValue(null);
        string defaultNameValueAsString = defaultNameValue == null ? null : defaultNameValue.ToString();
        return openSubKey != null &&
               (key.GetSubKeyNames().Contains(s) &&
                !string.IsNullOrEmpty(defaultNameValueAsString));
    }
