### PR TITLE
Fixed bug where cancelling on save-as crashed the application.

### DIFF
--- a/src/MarkPad/Document/DocumentViewModel.cs
+++ b/src/MarkPad/Document/DocumentViewModel.cs
@@ -114,7 +114,7 @@ namespace MarkPad.Document
                 .SaveAs()
                 .ContinueWith(t=>
                 {
-                    if (t.IsFaulted)
+                    if (t.IsFaulted || t.IsCanceled)
                         return false;
 
                     MarkpadDocument = t.Result;


### PR DESCRIPTION
That's it. A tiny pull request to prevent the app from crashing when you cancel the save-as dialog.
First one as well on my part, so I hope I'm not messing this up. :)

regards,
nj
