### PR TITLE
#382 - Ading option to invert the colors in the markdown editor (Gray background, white font color) 

### DIFF
--- a/src/MarkPad.sln
+++ b/src/MarkPad.sln
@@ -78,4 +78,7 @@ Global
 		{B780B8AD-169E-4300-A29F-713471EF3056} = {930C63A3-C919-4AA1-9292-DB3C4B81F4DA}
 		{F5EF3169-748F-4C96-A4A1-F33381572619} = {930C63A3-C919-4AA1-9292-DB3C4B81F4DA}
 	EndGlobalSection
+	GlobalSection(Performance) = preSolution
+		HasPerformanceSessions = true
+	EndGlobalSection
 EndGlobal

--- a/src/MarkPad/Converters/BoolToPreviewBackgroundConverter.cs
+++ b/src/MarkPad/Converters/BoolToPreviewBackgroundConverter.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Windows.Data;
+using System.Windows.Media;
+
+namespace MarkPad.Converters
+{
+    public class BoolToPreviewBackgroundConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            return (bool)value ? Brushes.DimGray : Brushes.White;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/MarkPad/Converters/BoolToPreviewForegroundConverter.cs
+++ b/src/MarkPad/Converters/BoolToPreviewForegroundConverter.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Windows.Data;
+using System.Windows.Media;
+
+namespace MarkPad.Converters
+{
+    public class BoolToPreviewForegroundConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            return (bool)value ? Brushes.White : Brushes.Black;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/MarkPad/Document/Controls/MarkdownEditor.xaml
+++ b/src/MarkPad/Document/Controls/MarkdownEditor.xaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="MarkPad.Document.Controls.MarkdownEditor"
+<UserControl
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:avalonedit="http://icsharpcode.net/sharpdevelop/avalonedit"
@@ -7,6 +7,7 @@
              xmlns:controls="clr-namespace:MarkPad.Document.Controls"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:UI="clr-namespace:MarkPad.Settings.UI" xmlns:Converters="clr-namespace:MarkPad.Converters" x:Class="MarkPad.Document.Controls.MarkdownEditor"
              x:Name="editor"
              d:DesignHeight="300"
              d:DesignWidth="300"
@@ -14,6 +15,8 @@
              mc:Ignorable="d">
     <UserControl.Resources>
         <ResourceDictionary>
+            <Converters:BoolToPreviewBackgroundConverter x:Key="BoolToPreviewBackgroundConverter"/>
+            <Converters:BoolToPreviewForegroundConverter x:Key="BoolToPreviewForegroundConverter"/>
             <Style TargetType="{x:Type avalonedit:TextArea}">
                 <Setter Property="FocusVisualStyle" Value="{x:Null}" />
                 <Setter Property="SelectionBrush">
@@ -37,8 +40,7 @@
                                               Focusable="False"
                                               FontFamily="Segoe UI"
                                               FontSize="10"
-                                              ItemsSource="{Binding RelativeSource={RelativeSource TemplatedParent},
-                                                                    Path=LeftMargins}"
+                                              ItemsSource="{Binding LeftMargins, RelativeSource={RelativeSource TemplatedParent}}"
                                               Padding="10,0,0,0">
                                     <ItemsControl.ItemsPanel>
                                         <ItemsPanelTemplate>
@@ -47,8 +49,7 @@
                                     </ItemsControl.ItemsPanel>
                                 </ItemsControl>
                                 <ContentPresenter Panel.ZIndex="-1"
-                                                  Content="{Binding RelativeSource={RelativeSource TemplatedParent},
-                                                                    Path=TextView}"
+                                                  Content="{Binding TextView, RelativeSource={RelativeSource TemplatedParent}}"
                                                   Focusable="False" />
                             </DockPanel>
                         </ControlTemplate>
@@ -73,64 +74,56 @@
     </UserControl.InputBindings>
     <Grid>
         <controls:FloatingToolBar x:Name="floatingToolBar"
-                                  HorizontalOffset="-30"
-                                  PlacementTarget="{Binding ElementName=Editor}"
-                                  VerticalOffset="-60">
+			HorizontalOffset="-30"
+			PlacementTarget="{Binding ElementName=Editor}"
+			VerticalOffset="-60">
             <Border Background="#f0f0f0"
-                    BorderBrush="#999999"
-                    BorderThickness="1"
-                    CornerRadius="1"
-                    Padding="3,2,3,2">
+				BorderBrush="#999999"
+				BorderThickness="1"
+				CornerRadius="1"
+				Padding="3,2,3,2">
                 <StackPanel Orientation="Horizontal">
                     <Button Width="22"
-                            Command="Commands:FormattingCommands.ToggleBold"
-                            ToolTip="Bold">
-                        B
-                    </Button>
+						Command="Commands:FormattingCommands.ToggleBold"
+						ToolTip="Bold" Content="B"/>
                     <Button Width="22"
-                            Command="Commands:FormattingCommands.ToggleItalic"
-                            ToolTip="Italic">
-                        I
-                    </Button>
+						Command="Commands:FormattingCommands.ToggleItalic"
+						ToolTip="Italic" Content="I"/>
                     <Button Width="44"
-                            Margin="5,0,0,0"
-                            Command="Commands:FormattingCommands.ToggleCode"
-                            ToolTip="Code">
-                        Code
-                    </Button>
+						Margin="5,0,0,0"
+						Command="Commands:FormattingCommands.ToggleCode"
+						ToolTip="Code" Content="Code"/>
                     <Button Width="78"
-                            Command="Commands:FormattingCommands.ToggleCodeBlock"
-                            ToolTip="Code block">
-                        Code block
-                    </Button>
+						Command="Commands:FormattingCommands.ToggleCodeBlock"
+						ToolTip="Code block" Content="Code block"/>
                     <Button Width="42"
-                            Command="Commands:FormattingCommands.SetHyperlink"
-                            ToolTip="Hyperlink">
-                        www
-                    </Button>
+						Command="Commands:FormattingCommands.SetHyperlink"
+						ToolTip="Hyperlink" Content="www"/>
                 </StackPanel>
             </Border>
         </controls:FloatingToolBar>
 
         <avalonedit:TextEditor x:Name="Editor"
-                               Grid.Column="0"
-                               Margin="10,0,10,10"
-                               HorizontalAlignment="Stretch"
-                               VerticalAlignment="Stretch"
-                               cal:Message.Attach="[Event TextChanged]=[Action Update]"
-                               ContextMenuOpening="EditorContextMenuOpening"
-                               Document="{Binding Document, ElementName=editor}"
-                               Padding="0,0,10,0"
-                               PreviewKeyDown="EditorPreviewKeyDown"
-                               RenderOptions.BitmapScalingMode="NearestNeighbor"
-                               ShowLineNumbers="True"
-                               TextOptions.TextFormattingMode="Display"
-                               WordWrap="True">
+			Grid.Column="0"
+			Margin="10,0,10,10"
+			HorizontalAlignment="Stretch"
+			VerticalAlignment="Stretch"
+			cal:Message.Attach="[Event TextChanged]=[Action Update]"
+			ContextMenuOpening="EditorContextMenuOpening"
+			Document="{Binding Document, ElementName=editor}"
+			Padding="0,0,10,0"
+			PreviewKeyDown="EditorPreviewKeyDown"
+			RenderOptions.BitmapScalingMode="NearestNeighbor"
+			ShowLineNumbers="True"
+			TextOptions.TextFormattingMode="Display"
+			WordWrap="True"
+			Foreground="{Binding IsColorsInverted, Converter={StaticResource BoolToPreviewForegroundConverter}}"
+            Background="{Binding IsColorsInverted, Converter={StaticResource BoolToPreviewBackgroundConverter}}">
             <avalonedit:TextEditor.Effect>
                 <DropShadowEffect BlurRadius="10"
-                                  Direction="270"
-                                  Opacity="0.25"
-                                  Color="Black" />
+					Direction="270"
+					Opacity="0.25"
+					Color="Black" />
             </avalonedit:TextEditor.Effect>
             <avalonedit:TextEditor.ContextMenu>
                 <ContextMenu x:Name="EditorContextMenu" MenuItem.Click="SpellcheckerWordClick" />

--- a/src/MarkPad/Document/Controls/MarkdownEditor.xaml.cs
+++ b/src/MarkPad/Document/Controls/MarkdownEditor.xaml.cs
@@ -364,5 +364,14 @@ namespace MarkPad.Document.Controls
             get { return (ISpellCheckProvider) GetValue(SpellcheckProviderProperty); }
             set { SetValue(SpellcheckProviderProperty, value); }
         }
+
+        public static readonly DependencyProperty IsColorsInvertedProperty =
+            DependencyProperty.Register("IsColorsInverted", typeof(bool), typeof(MarkdownEditor));
+
+        public bool IsColorsInverted
+        {
+            get { return (bool) GetValue(IsColorsInvertedProperty); } 
+            set { SetValue(IsColorsInvertedProperty, value);}
+        }
     }
 }

--- a/src/MarkPad/Document/DocumentView.xaml
+++ b/src/MarkPad/Document/DocumentView.xaml
@@ -60,7 +60,9 @@
                                  IndentType="{Binding IndentType}"
                                  EditorFontSize="{Binding FontSize}"
                                  Document="{Binding Document}"
-                                 SpellCheckProvider="{Binding SpellCheckProvider}"/>
+                                 SpellCheckProvider="{Binding SpellCheckProvider}"
+                                 IsColorsInverted="{Binding IsColorsInverted}"
+                                 />
         
         <Border Grid.Column="2" 
                 SizeChanged="PlaceHolderSizeChanged"

--- a/src/MarkPad/Document/DocumentView.xaml.cs
+++ b/src/MarkPad/Document/DocumentView.xaml.cs
@@ -134,6 +134,7 @@ namespace MarkPad.Document
             ApplyFont();
             markdownEditor.Editor.TextArea.TextView.Redraw();
             ViewModel.ExecuteSafely(vm => vm.RefreshFont());
+            ViewModel.ExecuteSafely(vm => vm.RefreshColors());
         }
 
         void PlaceHolderSizeChanged(object sender, SizeChangedEventArgs e)

--- a/src/MarkPad/Document/DocumentViewModel.cs
+++ b/src/MarkPad/Document/DocumentViewModel.cs
@@ -54,6 +54,7 @@ namespace MarkPad.Document
             SearchProvider = searchProvider;
 
             FontSize = GetFontSize();
+            IsColorsInverted = GetIsColorsInverted();
             IndentType = settingsProvider.GetSettings<MarkPadSettings>().IndentType;
             
             Original = "";
@@ -263,6 +264,8 @@ namespace MarkPad.Document
 
         public double FontSize { get; private set; }
 
+        public bool IsColorsInverted { get; set; }
+
         public double ZoomLevel
         {
             get { return zoomLevel; }
@@ -292,6 +295,11 @@ namespace MarkPad.Document
         private int GetFontSize()
         {
             return Constants.FONT_SIZE_ENUM_ADJUSTMENT + (int)settingsProvider.GetSettings<MarkPadSettings>().FontSize;
+        }
+
+        private bool GetIsColorsInverted()
+        {
+            return settingsProvider.GetSettings<MarkPadSettings>().IsEditorColorsInverted;
         }
 
         public void ZoomIn()
@@ -347,6 +355,11 @@ namespace MarkPad.Document
         public void RefreshFont()
         {
             FontSize = GetFontSize()*ZoomLevel;
+        }
+
+        public void RefreshColors()
+        {
+            IsColorsInverted = GetIsColorsInverted();
         }
 
         public void Handle(SettingsChangedEvent message)

--- a/src/MarkPad/MarkPad.csproj
+++ b/src/MarkPad/MarkPad.csproj
@@ -185,6 +185,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Behaviors\StateHelper.cs" />
+    <Compile Include="Converters\BoolToPreviewBackgroundConverter.cs" />
+    <Compile Include="Converters\BoolToPreviewForegroundConverter.cs" />
     <Compile Include="DocumentSources\IOpenDocumentFromWeb.cs" />
     <Compile Include="DocumentSources\NewDocument\NewDocumentContext.cs" />
     <Compile Include="DocumentSources\OpenDocumentFromWeb.cs" />

--- a/src/MarkPad/Settings/Models/MarkPadSettings.cs
+++ b/src/MarkPad/Settings/Models/MarkPadSettings.cs
@@ -27,5 +27,7 @@ namespace MarkPad.Settings.Models
 
         [DefaultValue(SpellingLanguages.Australian)]
         public SpellingLanguages Language { get; set; }
+
+        public bool IsEditorColorsInverted { get; set; }
     }
 }

--- a/src/MarkPad/Settings/UI/SettingsView.xaml
+++ b/src/MarkPad/Settings/UI/SettingsView.xaml
@@ -17,6 +17,8 @@
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Accents/BaseDark.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/MarkPad;component/Styles/MarkPad.Accents.xaml" />
             </ResourceDictionary.MergedDictionaries>
+            <Converters:BoolToPreviewForegroundConverter x:Key="BoolToPreviewForegroundConverter"/>
+            <Converters:BoolToPreviewBackgroundConverter x:Key="BoolToPreviewBackgroundConverter"/>
         </ResourceDictionary>
     </UserControl.Resources>
     <Grid  Background="Black">
@@ -178,23 +180,26 @@
                             </ComboBox>
 
                             <TextBlock Text="PREVIEW"  FontWeight="SemiBold"  FontSize="12" Margin="0,5,0,0"/>
-                            <Border BorderBrush="{x:Null}" Background="#4D4D4D" Height="83">
+                            <Border BorderBrush="{x:Null}" Background="{Binding IsColorsInverted, Converter={StaticResource BoolToPreviewBackgroundConverter}}" Height="83">
                                 <TextBlock TextWrapping="Wrap"							   
                                             TextAlignment="Center"
                                             VerticalAlignment="Center"
-                                            Foreground="White"
                                             FontFamily="{Binding SelectedFontFamily}"
                                             FontSize="{Binding SelectedActualFontSize}"
+                                            Foreground="{Binding IsColorsInverted, Converter={StaticResource BoolToPreviewForegroundConverter}}"
                                             Text="MarkPad is an editor for Markdown"/>
                             </Border>
                         </StackPanel>
-                        <Button Width="75" x:Name="ResetFont" Content="Reset" Style="{DynamicResource SquareButtonStyle}"  HorizontalAlignment="Right" Grid.Row="2" Grid.ColumnSpan="2" Margin="0 10 0 0">
-                            <i:Interaction.Triggers>
-                                <i:EventTrigger EventName="Click">
-                                    <cal:ActionMessage MethodName="ResetFont" />
-                                </i:EventTrigger>
-                            </i:Interaction.Triggers>
-                        </Button>
+                        <StackPanel Grid.Row="3" Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right">
+                            <CheckBox Content="Invert Colors" HorizontalAlignment="Right" HorizontalContentAlignment="Right" VerticalAlignment="Bottom"  Margin="10 10 10 10" IsChecked="{Binding IsColorsInverted}" />
+                            <Button Width="75" x:Name="ResetFont" Content="Reset" Style="{DynamicResource SquareButtonStyle}" VerticalAlignment="Bottom" HorizontalAlignment="Right" Margin="10 10 10 10">
+                                <i:Interaction.Triggers>
+                                    <i:EventTrigger EventName="Click">
+                                        <cal:ActionMessage MethodName="ResetFont" />
+                                    </i:EventTrigger>
+                                </i:Interaction.Triggers>
+                            </Button>
+                        </StackPanel>
                     </Grid>
 				</StackPanel>
             </TabItem>

--- a/src/MarkPad/Settings/UI/SettingsViewModel.cs
+++ b/src/MarkPad/Settings/UI/SettingsViewModel.cs
@@ -43,6 +43,7 @@ namespace MarkPad.Settings.UI
         public IndentType IndentType { get; set; }
         public bool CanEditBlog { get { return currentBlog != null; } }
         public bool CanRemoveBlog { get { return currentBlog != null; } }
+        public bool IsColorsInverted { get; set; }
         public BlogSetting CurrentBlog
         {
             get { return currentBlog; }
@@ -129,6 +130,7 @@ namespace MarkPad.Settings.UI
                 SelectedFontSize = Constants.DEFAULT_EDITOR_FONT_SIZE;
             }
             EnableFloatingToolBar = settings.FloatingToolBarEnabled;
+            IsColorsInverted = settings.IsEditorColorsInverted;
 
             Plugins = plugins
                 .Where(plugin => !plugin.IsHidden)
@@ -171,6 +173,7 @@ namespace MarkPad.Settings.UI
         {
             SelectedFontFamily = FontHelpers.TryGetFontFamilyFromStack(Constants.DEFAULT_EDITOR_FONT_FAMILY);
             SelectedFontSize = Constants.DEFAULT_EDITOR_FONT_SIZE;
+            IsColorsInverted = false;
         }
 
         public void Accept()
@@ -198,6 +201,7 @@ namespace MarkPad.Settings.UI
             settings.FontSize = SelectedFontSize;
             settings.FontFamily = SelectedFontFamily.Source;
             settings.FloatingToolBarEnabled = EnableFloatingToolBar;
+            settings.IsEditorColorsInverted = IsColorsInverted;
             settings.IndentType = IndentType;
             settings.Language = SelectedLanguage;
 


### PR DESCRIPTION
For supporting white letters on a dark gray background in the editor
