### PR TITLE
#397 - Added fix for overtpye not being triggered with modifier keys. 

### DIFF
--- a/src/MarkPad/Document/EditorBehaviours/OvertypeMode.cs
+++ b/src/MarkPad/Document/EditorBehaviours/OvertypeMode.cs
@@ -10,7 +10,7 @@ namespace MarkPad.Document.EditorBehaviours
     {
         public void Handle(EditorPreviewKeyDownEvent e)
         {
-            if (e.Args.Key != Key.Insert) return;
+            if (e.Args.Key != Key.Insert || Keyboard.Modifiers != ModifierKeys.None) return;
 
             e.ViewModel.Overtype = !e.ViewModel.Overtype;
             e.Args.Handled = true;


### PR DESCRIPTION
This allows Ctrl+Insert and Shift+Insert to work properly.
