### PR TITLE
#266 - Added automatic paired characters

### DIFF
--- a/src/MarkPad/Document/DocumentViewModel.cs
+++ b/src/MarkPad/Document/DocumentViewModel.cs
@@ -15,6 +15,7 @@ using MarkPad.Settings;
 using MarkPad.Settings.Models;
 using Ookii.Dialogs.Wpf;
 using Action = System.Action;
+using MarkPad.Document.EditorBehaviours;
 
 namespace MarkPad.Document
 {
@@ -42,9 +43,11 @@ namespace MarkPad.Document
             IDocumentParser documentParser,
             ISpellCheckProvider spellCheckProvider,
             ISearchProvider searchProvider,
-            IShell shell)
+            IShell shell,
+            IPairedCharsHighlightProvider pairedCharsHighlightProvider)
         {
             SpellCheckProvider = spellCheckProvider;
+            PairedCharsHighlightProvider = pairedCharsHighlightProvider;
             this.dialogService = dialogService;
             this.windowManager = windowManager;
             this.settingsProvider = settingsProvider;
@@ -252,6 +255,8 @@ namespace MarkPad.Document
         {
             if (SpellCheckProvider != null)
                 SpellCheckProvider.Disconnect();
+            if (PairedCharsHighlightProvider != null)
+                PairedCharsHighlightProvider.Disconnect();
             var disposableSiteContext = MarkpadDocument.SiteContext as IDisposable;
             if (disposableSiteContext != null)
                 disposableSiteContext.Dispose();
@@ -373,9 +378,12 @@ namespace MarkPad.Document
 
         public ISpellCheckProvider SpellCheckProvider { get; private set; }
 
+        public IPairedCharsHighlightProvider PairedCharsHighlightProvider { get; private set; }
+
         protected override void OnViewLoaded(object view)
         {
             SpellCheckProvider.Initialise((DocumentView)view);
+            PairedCharsHighlightProvider.Initialise((DocumentView)view);
             SearchProvider.Initialise((DocumentView)view);
             base.OnViewLoaded(view);
             NotifyOfPropertyChange(()=>View);

--- a/src/MarkPad/Document/EditorBehaviours/AutoPairedCharacters.cs
+++ b/src/MarkPad/Document/EditorBehaviours/AutoPairedCharacters.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using System.Windows.Input;
+using Caliburn.Micro;
+using ICSharpCode.AvalonEdit;
+using MarkPad.Document.Events;
+using System.Collections.Generic;
+using ICSharpCode.AvalonEdit.Document;
+using ICSharpCode.AvalonEdit.Rendering;
+using System.Windows;
+using System.Windows.Media;
+using System.Linq;
+
+namespace MarkPad.Document.EditorBehaviours
+{
+    class AutoPairedCharacters : IHandle<EditorTextEnteredEvent>, IHandle<EditorTextEnteringEvent>, IHandle<EditorPreviewKeyDownEvent>
+    {
+        private static Dictionary<string, string> pairedChars = new Dictionary<string, string>()
+        {
+            {"(",")"},
+            {"[","]"},
+            {"{","}"},
+            {"'","'"},
+            {"\"","\""},
+            {"<",">"}
+        };
+
+        private PairedCharacterRenderer pairedCharacterRenderer;
+        private HashSet<string> validFollowingChars;
+
+        public AutoPairedCharacters()
+        {
+            pairedCharacterRenderer = new PairedCharacterRenderer();
+            validFollowingChars = new HashSet<string>() { "", " " };
+            pairedChars.Values.ToList().ForEach(v => validFollowingChars.Add(v));
+        }
+
+        public void Handle(EditorTextEnteredEvent e)
+        {
+        }
+
+        public void Handle(EditorTextEnteringEvent e)
+        {
+            if (pairedChars.Any(pc => pc.Value == e.Args.Text) && e.Editor.GetNextCharacter() == e.Args.Text
+                && GetOpeningCharPosition(e.Args.Text, e.Editor.CaretOffset, e.Editor) != -1)
+            {
+                //type 'over' the next character
+                e.Editor.SelectionLength = 1;
+            }
+            else if (ValidInsertPosition(e.Editor) && pairedChars.ContainsKey(e.Args.Text))
+            {
+                //insert the paired character
+                var charactedToInsert = pairedChars[e.Args.Text];
+                e.Editor.TextArea.Selection.ReplaceSelectionWithText(charactedToInsert);
+                e.Editor.CaretOffset -= charactedToInsert.Length;
+            }
+        }
+
+        public void Handle(EditorPreviewKeyDownEvent e)
+        {
+            if (e.Args.Key == Key.Back && e.Editor.CaretOffset > 0)
+            {
+                var textToRemove = e.Editor.Document.GetText(e.Editor.CaretOffset - 1, 1);
+
+                if (pairedChars.ContainsKey(textToRemove) && e.Editor.GetNextCharacter() == pairedChars[textToRemove])
+                {
+                    //remove the paired character
+                    e.Editor.Select(e.Editor.CaretOffset, 1);
+                    e.Editor.TextArea.Selection.ReplaceSelectionWithText("");
+                }
+            }
+        }
+
+        public static bool IsValidOpeningCharacter(string character)
+        {
+            return pairedChars.ContainsKey(character);
+        }
+
+        public static bool IsValidClosingCharacter(string character)
+        {
+            return pairedChars.ContainsValue(character);
+        }
+
+        public static int GetClosingCharPosition(string openingChar, int startAt, TextEditor editor)
+        {
+            var closeChar = pairedChars[openingChar];
+            int count = 0;
+            var startingPosition = startAt - 1;
+
+            var nextChar = "";
+            do
+            {
+                startingPosition++;
+                nextChar = editor.GetNextCharacter(startingPosition);
+                
+                if (nextChar == closeChar)
+                    count--;
+                else if (nextChar == openingChar)
+                    count++;
+
+            } while ((nextChar != closeChar || count > -1) && nextChar != "");
+
+            return startingPosition < editor.Document.TextLength ? startingPosition : -1;
+        }
+
+        public static int GetOpeningCharPosition(string closingChar, int startAt, TextEditor editor)
+        {
+            var openChar = pairedChars.Single(pc => pc.Value == closingChar).Key;
+            int count = 0;
+            var startingPosition = startAt;
+
+            var nextChar = "";
+            do
+            {
+                startingPosition--;
+                nextChar = editor.GetNextCharacter(startingPosition);
+
+                if (nextChar == openChar)
+                    count--;
+                else if (nextChar == closingChar)
+                    count++;
+
+            } while ((nextChar != openChar || count > -1) && nextChar != "");
+
+            return startingPosition >= 0 ? startingPosition : -1;
+        }
+
+        private bool ValidInsertPosition(TextEditor editor)
+        {
+            return validFollowingChars.Contains(editor.GetNextCharacter());
+        }
+    }
+}

--- a/src/MarkPad/Document/EditorBehaviours/IPairedCharsHighlightProvider.cs
+++ b/src/MarkPad/Document/EditorBehaviours/IPairedCharsHighlightProvider.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MarkPad.Document.EditorBehaviours
+{
+    public interface IPairedCharsHighlightProvider
+    {
+        void Initialise(DocumentView documentView);
+        void Disconnect();
+    }
+}

--- a/src/MarkPad/Document/EditorBehaviours/PairedCharacterRenderer.cs
+++ b/src/MarkPad/Document/EditorBehaviours/PairedCharacterRenderer.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using ICSharpCode.AvalonEdit.Document;
+using ICSharpCode.AvalonEdit.Rendering;
+using System.Windows;
+using System.Windows.Media;
+
+namespace MarkPad.Document.EditorBehaviours
+{
+    public class PairedCharacterRenderer : IBackgroundRenderer
+    {
+        private Brush highlightBrush;
+        private Pen highlightPen;
+
+        public PairedCharacterRenderer()
+        {
+            highlightBrush = new SolidColorBrush(Colors.LightBlue);
+            highlightPen = new Pen(highlightBrush, 1.0);
+
+            PairedCharacters = new TextSegmentCollection<TextSegment>();
+        }
+
+        public TextSegmentCollection<TextSegment> PairedCharacters { get; private set; }
+
+        private IEnumerable<Point> CreatePoints(Point start, Point end, double offset, int count)
+        {
+            for (int i = 0; i < count; i++)
+            {
+                yield return new Point(start.X + (double)i * offset, start.Y - (((i + 1) % 2 == 0) ? offset : 0.0));
+            }
+            yield break;
+        }
+
+        public void Draw(TextView textView, DrawingContext drawingContext)
+        {
+            foreach (TextSegment character in this.PairedCharacters)
+            {
+                foreach (Rect characterRect in BackgroundGeometryBuilder.GetRectsForSegment(textView, character))
+                {
+                    drawingContext.DrawRectangle(highlightBrush, highlightPen, characterRect); 
+                }
+            }
+        }
+
+        public KnownLayer Layer
+        {
+            get { return KnownLayer.Selection; }
+        }
+    }
+}

--- a/src/MarkPad/Document/EditorBehaviours/PairedCharsHighlightProvider.cs
+++ b/src/MarkPad/Document/EditorBehaviours/PairedCharsHighlightProvider.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Windows.Input;
+using ICSharpCode.AvalonEdit;
+using MarkPad.Document.Events;
+using ICSharpCode.AvalonEdit.Document;
+using ICSharpCode.AvalonEdit.Rendering;
+
+namespace MarkPad.Document.EditorBehaviours
+{
+    class PairedCharsHighlightProvider : IPairedCharsHighlightProvider
+    {
+        readonly PairedCharacterRenderer pairedCharacterRenderer;
+        DocumentView view;
+
+        public PairedCharsHighlightProvider()
+        {
+            pairedCharacterRenderer = new PairedCharacterRenderer();
+        }
+
+        public void Initialise(DocumentView documentView)
+        {
+            view = documentView;
+            view.TextView.BackgroundRenderers.Add(pairedCharacterRenderer);
+            view.TextView.VisualLinesChanged += TextViewVisualLinesChanged;
+            view.Editor.TextArea.Caret.PositionChanged += TextAreaCaretPositionChanged;
+        }
+
+        public void Disconnect()
+        {
+            if (view == null) return;
+            view.TextView.BackgroundRenderers.Remove(pairedCharacterRenderer);
+            view.TextView.VisualLinesChanged -= TextViewVisualLinesChanged;
+            view = null;
+        }
+
+        void TextViewVisualLinesChanged(object sender, EventArgs e)
+        {
+            MarkPreviousChar();
+        }
+
+        void TextAreaCaretPositionChanged(object sender, EventArgs e)
+        {
+            MarkPreviousChar(); 
+            
+            //force a refresh
+            view.Editor.TextArea.TextView.InvalidateLayer(KnownLayer.Background);
+        }
+
+        void MarkPreviousChar()
+        {
+            //clear any existing highlights
+            pairedCharacterRenderer.PairedCharacters.Clear();
+
+            var caretOffset = view.Editor.CaretOffset;
+
+            //check if the current character has a paired character
+            var currentChar = view.Editor.GetPrevCharacter();
+            if (AutoPairedCharacters.IsValidOpeningCharacter(currentChar))
+            {
+                var closePos = AutoPairedCharacters.GetClosingCharPosition(currentChar, view.Editor.CaretOffset, view.Editor);
+                if (closePos != -1)
+                {
+                    pairedCharacterRenderer.PairedCharacters.Add(new TextSegment
+                    {
+                        StartOffset = caretOffset - 1,
+                        Length = 1
+                    });
+
+                    pairedCharacterRenderer.PairedCharacters.Add(new TextSegment
+                    {
+                        StartOffset = closePos,
+                        Length = 1
+                    });
+                }
+            }
+            else if (AutoPairedCharacters.IsValidClosingCharacter(currentChar))
+            {
+                var openPos = AutoPairedCharacters.GetOpeningCharPosition(currentChar, view.Editor.CaretOffset - 1, view.Editor);
+                if (openPos != -1)
+                {
+                    pairedCharacterRenderer.PairedCharacters.Add(new TextSegment
+                    {
+                        StartOffset = caretOffset - 1,
+                        Length = 1
+                    });
+
+                    pairedCharacterRenderer.PairedCharacters.Add(new TextSegment
+                    {
+                        StartOffset = openPos,
+                        Length = 1
+                    });
+                }
+            }
+        }
+    }
+}

--- a/src/MarkPad/Document/EditorBehaviours/TextEditorExtensions.cs
+++ b/src/MarkPad/Document/EditorBehaviours/TextEditorExtensions.cs
@@ -21,5 +21,49 @@ namespace MarkPad.Document.EditorBehaviours
             return editor.Document.GetText(currentLine.Offset, editor.CaretOffset - currentLine.Offset);
         }
 
+        public static string GetPrevCharacter(this TextEditor editor)
+        {
+            return GetPrevCharacter(editor, editor.CaretOffset);
+        }
+
+        public static string GetPrevCharacter(this TextEditor editor, int position)
+        {
+            if (position < 1) return "";
+            return editor.Document.GetText(position - 1, 1);
+        }
+
+        public static string GetNextCharacter(this TextEditor editor)
+        {
+            return GetNextCharacter(editor, editor.CaretOffset);
+        }
+
+        public static string GetNextCharacter(this TextEditor editor, int position)
+        {
+            if (position < 0) return "";
+            if (editor.Document.TextLength == position) return "";
+            return editor.Document.GetText(position, 1);
+        }
+
+        /*public static void MoveToPrevInstanceOfString(TextEditor editor, string match)
+        {
+            if (match.Equals(TextEditorExtensions.GetNextCharacter(editor))) return;
+            if (editor.IsCaratAtEndOfLine()) return;
+            if (editor.CaretOffset >= editor.Document.TextLength) return;
+
+            editor.CaretOffset++;
+
+            MoveToPrevInstanceOfString(editor, match);
+        }
+
+        public static void MoveToNextInstanceOfString(TextEditor editor, string match)
+        {
+            if (match.Equals(TextEditorExtensions.GetNextCharacter(editor))) return;
+            if (editor.IsCaratAtEndOfLine()) return;
+            if (editor.CaretOffset >= editor.Document.TextLength) return;
+
+            editor.CaretOffset++;
+
+            MoveToNextInstanceOfString(editor, match);
+        }*/
     }
 }

--- a/src/MarkPad/Document/Events/EditorTextEnteredEvent.cs
+++ b/src/MarkPad/Document/Events/EditorTextEnteredEvent.cs
@@ -1,0 +1,19 @@
+﻿using System.Windows.Input;
+using ICSharpCode.AvalonEdit;
+
+namespace MarkPad.Document.Events
+{
+    class EditorTextEnteredEvent
+    {
+        public DocumentViewModel ViewModel { get; private set; }
+        public TextEditor Editor { get; private set; }
+        public TextCompositionEventArgs Args { get; private set; }
+
+        public EditorTextEnteredEvent(DocumentViewModel viewModel, TextEditor editor, TextCompositionEventArgs args)
+        {
+            ViewModel = viewModel;
+            Editor = editor;
+            Args = args;
+        }
+    }
+}

--- a/src/MarkPad/Infrastructure/MarkPadAutofacModule.cs
+++ b/src/MarkPad/Infrastructure/MarkPadAutofacModule.cs
@@ -2,6 +2,7 @@ using Autofac;
 using MarkPad.Document;
 using MarkPad.Document.Search;
 using MarkPad.Document.SpellCheck;
+using MarkPad.Document.EditorBehaviours;
 using MarkPad.DocumentSources;
 using MarkPad.DocumentSources.MetaWeblog;
 using MarkPad.Infrastructure.Abstractions;
@@ -35,6 +36,7 @@ namespace MarkPad.Infrastructure
 			});
             builder.RegisterType<SearchProvider>().As<ISearchProvider>();
             builder.RegisterType<SearchSettings>().SingleInstance();
+            builder.RegisterType<PairedCharsHighlightProvider>().As<IPairedCharsHighlightProvider>();
 		}
 	}
 }

--- a/src/MarkPad/MarkPad.csproj
+++ b/src/MarkPad/MarkPad.csproj
@@ -187,6 +187,11 @@
   <ItemGroup>
     <Compile Include="Behaviors\StateHelper.cs" />
     <Compile Include="Constants.cs" />
+    <Compile Include="Document\EditorBehaviours\AutoPairedCharacters.cs" />
+    <Compile Include="Document\EditorBehaviours\PairedCharsHighlightProvider.cs" />
+    <Compile Include="Document\EditorBehaviours\PairedCharacterRenderer.cs" />
+    <Compile Include="Document\Events\EditorTextEnteredEvent.cs" />
+    <Compile Include="Document\EditorBehaviours\IPairedCharsHighlightProvider.cs" />
     <Compile Include="FontSizes.cs" />
     <Compile Include="Converters\BoolToPreviewBackgroundConverter.cs" />
     <Compile Include="Converters\BoolToPreviewForegroundConverter.cs" />


### PR DESCRIPTION
Implemented paired characters, as described in issue #266. For the characters  (), [], {}, '', "", <>:
1. When inserting the opening char, the closing char gets added automatically. 
2. Deletion of the closing brace is automatic when backspacing the opening char, and the close is immediately to the right. 
3. Overtyping of the closing brace is also implemented. 
4. Highlighting of matching pairs has also been added.
