### PR TITLE
Added support for a user created dictionary.

### DIFF
--- a/src/MarkPad/Document/Commands/DelegateCommand.cs
+++ b/src/MarkPad/Document/Commands/DelegateCommand.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Windows.Input;
+
+namespace MarkPad.Document.Commands
+{
+    public class DelegateCommand : ICommand
+    {
+        public event EventHandler CanExecuteChanged;
+
+        private string displayName;
+        Func<object, bool> canExecute;
+        Action<object> execute;
+
+        public DelegateCommand(string displayName, Action<object> execute, Func<object, bool> canExecute = null)
+        {
+            this.displayName = displayName;
+            this.execute = execute;
+            this.canExecute = canExecute;
+        }
+
+        public bool CanExecute(object parameter)
+        {
+            return canExecute == null || canExecute(parameter);
+        }
+
+        public void Execute(object parameter)
+        {
+            execute(parameter);
+        }
+
+        public override string ToString()
+        {
+            return displayName;
+        }
+    }
+}

--- a/src/MarkPad/Document/SpellCheck/ISpellCheckProvider.cs
+++ b/src/MarkPad/Document/SpellCheck/ISpellCheckProvider.cs
@@ -8,6 +8,7 @@ namespace MarkPad.Document.SpellCheck
 	    void Initialise(DocumentView documentView);
 	    IEnumerable<TextSegment> GetSpellCheckErrors();
 	    IEnumerable<string> GetSpellcheckSuggestions(string word);
+        void AddWordToCustomDictionary(string word);
 	    void Disconnect();
 	}
 }

--- a/src/MarkPad/Document/SpellCheck/ISpellingService.cs
+++ b/src/MarkPad/Document/SpellCheck/ISpellingService.cs
@@ -8,5 +8,6 @@ namespace MarkPad.Document.SpellCheck
 		void SetLanguage(SpellingLanguages language);
 		bool Spell(string word);
         IEnumerable<string> Suggestions(string word);
-	}
+        void AddWordToCustomDictionary(string word);
+    }
 }

--- a/src/MarkPad/Document/SpellCheck/MultiHunspell.cs
+++ b/src/MarkPad/Document/SpellCheck/MultiHunspell.cs
@@ -1,0 +1,42 @@
+﻿using NHunspell;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MarkPad.Document.SpellCheck
+{
+    public class MultiHunspell : IDisposable
+    {
+        private readonly IList<Hunspell> hunspells = new List<Hunspell>();
+
+        public void Dispose()
+        {
+            Clear();
+        }
+
+        public bool Spell(string word)
+        {
+            if (hunspells.Count == 0)
+                return true;
+            return hunspells.Any(x => x.Spell(word));
+        }
+
+        public IEnumerable<string> Suggestions(string word)
+        {
+            return hunspells.SelectMany(x => x.Suggest(word));
+        }
+
+        public void AddHunspell(Hunspell hunspell)
+        {
+            hunspells.Add(hunspell);
+        }
+
+        public void Clear()
+        {
+            foreach (var speller in hunspells)
+                speller.Dispose();
+            hunspells.Clear();
+        }
+    }
+}

--- a/src/MarkPad/Document/SpellCheck/SpellCheckProvider.cs
+++ b/src/MarkPad/Document/SpellCheck/SpellCheckProvider.cs
@@ -101,7 +101,12 @@ namespace MarkPad.Document.SpellCheck
         {
             if (spellCheckRenderer == null) return Enumerable.Empty<string>();
             return spellingService.Suggestions(word);
-        } 
-    }
+        }
 
+        public void AddWordToCustomDictionary(string word)
+        {
+            spellingService.AddWordToCustomDictionary(word);
+            DoSpellCheck();
+        }
+    }
 }

--- a/src/MarkPad/Document/SpellCheck/SpellingService.cs
+++ b/src/MarkPad/Document/SpellCheck/SpellingService.cs
@@ -9,7 +9,8 @@ namespace MarkPad.Document.SpellCheck
     public class SpellingService : ISpellingService
     {
         static readonly Dictionary<SpellingLanguages, string> LangLookup;
-        Hunspell speller;
+        readonly MultiHunspell speller = new MultiHunspell();
+        SpellingLanguages currentLanguage;
 
         static SpellingService()
         {
@@ -26,22 +27,23 @@ namespace MarkPad.Document.SpellCheck
 
         public bool Spell(string word)
         {
-            return speller == null || speller.Spell(word);
+            return speller.Spell(word);
         }
 
         public IEnumerable<string> Suggestions(string word)
         {
-            return speller.Suggest(word);
+            return speller.Suggestions(word);
         }
 
         public void ClearLanguages()
         {
-            speller = null;
+            speller.Clear();
         }
 
         public void SetLanguage(SpellingLanguages language)
         {
-            speller = new Hunspell();
+            currentLanguage = language;
+            speller.Clear();
 
             var languageKey = LangLookup[language];
 
@@ -68,10 +70,45 @@ namespace MarkPad.Document.SpellCheck
                         var affBytes = new BinaryReader(affStream).ReadBytes((int)affStream.Length);
                         var dicBytes = new BinaryReader(dicStream).ReadBytes((int)dicStream.Length);
 
-                        speller.Load(affBytes, dicBytes);
+                        var newSpeller = new Hunspell(affBytes, dicBytes);
+                        speller.AddHunspell(newSpeller);
                     }
                 }
             }
+
+            var customDictionaryPath = GetCustomDictionaryPath();
+            if (File.Exists(customDictionaryPath))
+            {
+                var newSpeller = new Hunspell(new byte[] {}, File.ReadAllBytes(customDictionaryPath));
+                speller.AddHunspell(newSpeller);
+            }
+        }
+
+        public void AddWordToCustomDictionary(string word)
+        {
+            var customDictionaryPath = GetCustomDictionaryPath();
+
+            IList<string> lines = File.Exists(customDictionaryPath)
+                ? File.ReadAllLines(customDictionaryPath).Skip(1).ToList() // first line is count
+                : new List<string>();
+
+            if (!lines.Contains(word))
+            {
+                lines.Add(word);
+
+                File.WriteAllText(
+                    customDictionaryPath,
+                    lines.Count() + "\n" + string.Join("\n", lines).TrimEnd('\n') + "\n");
+
+                SetLanguage(currentLanguage); // reloads dictionary
+            }
+        }
+
+        private static string GetCustomDictionaryPath()
+        {
+            return Path.Combine(
+                Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+                "custom.dic");
         }
     }
 }

--- a/src/MarkPad/MarkPad.csproj
+++ b/src/MarkPad/MarkPad.csproj
@@ -187,10 +187,12 @@
   <ItemGroup>
     <Compile Include="Behaviors\StateHelper.cs" />
     <Compile Include="Constants.cs" />
+    <Compile Include="Document\Commands\DelegateCommand.cs" />
     <Compile Include="Document\EditorBehaviours\AutoPairedCharacters.cs" />
     <Compile Include="Document\EditorBehaviours\PairedCharsHighlightProvider.cs" />
     <Compile Include="Document\EditorBehaviours\PairedCharacterRenderer.cs" />
     <Compile Include="Document\EditorBehaviours\IPairedCharsHighlightProvider.cs" />
+    <Compile Include="Document\SpellCheck\MultiHunspell.cs" />
     <Compile Include="FontSizes.cs" />
     <Compile Include="Converters\BoolToPreviewBackgroundConverter.cs" />
     <Compile Include="Converters\BoolToPreviewForegroundConverter.cs" />


### PR DESCRIPTION
To address #387.

Specifically, it provides the ability to add misspelled words to a custom spellcheck dictionary file that's created the first time it's done. Maybe this file should be supplied with the application pre-seeded with techno jargon (like the word "permalink" mentioned in the issue)?
