### PR TITLE
Restyle syntax highlighting #270

### DIFF
--- a/src/MarkPad/Document/Controls/MarkdownEditor.xaml.cs
+++ b/src/MarkPad/Document/Controls/MarkdownEditor.xaml.cs
@@ -7,6 +7,7 @@ using System.Text.RegularExpressions;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Media;
 using System.Xml;
 using Caliburn.Micro;
 using ICSharpCode.AvalonEdit;
@@ -68,6 +69,9 @@ namespace MarkPad.Document.Controls
                 overtypeMode,
                 autoPairedCharacters
             };
+
+            Editor.TextArea.TextView.LinkTextForegroundBrush = new SolidColorBrush(
+                Color.FromRgb(0xA4, 0xA4, 0xA4));
         }
 
         #region public IndentType IndentType

--- a/src/MarkPad/Syntax/Markdown.xshd
+++ b/src/MarkPad/Syntax/Markdown.xshd
@@ -5,16 +5,10 @@
 
 
   <RuleSet ignoreCase="false">
-    <Import ruleSet="HTML/"/>
     <Span>
       <Begin color="String">\*</Begin>
       <End color="String">\*</End>
     </Span>
-    <Span color="Code">
-      <Begin>`</Begin>
-      <End>`</End>
-    </Span>
-    <Span color="Code" begin="\t" />
     <Span>
       <Begin color="Url">\!\[</Begin>
       <End color="Url">\]</End>


### PR DESCRIPTION
Remove color highlighting from code blocks, all html elements and change url highlighting color. To remove underlining of urls we need a more recent version of Avalon Edit (according to https://stackoverflow.com/questions/24803790/avalonedit-how-to-remove-hyperlink-underline)
